### PR TITLE
feat: add install.sh bootstrap for curl | sh one-liner

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,236 @@
+#!/bin/sh
+# GSE-One — curl | sh bootstrap installer.
+# Spec: docs/specs/curl-plugin-based-install.md
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/nicolasguelfi/gensem/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/nicolasguelfi/gensem/main/install.sh | sh -s -- uninstall
+#   curl -fsSL https://raw.githubusercontent.com/nicolasguelfi/gensem/main/install.sh | sh -s -- upgrade
+#
+# Env overrides:
+#   GSE_PLATFORM   claude|cursor|opencode|all|both   (default: auto-detect)
+#   GSE_MODE       plugin|no-plugin                  (default: auto-detect)
+#   GSE_SCOPE      project|local|user                (default: user)
+#   GSE_VERSION    vX.Y.Z|latest                     (default: latest)
+#   GSE_PROJECT_DIR /abs/path                        (no-plugin only)
+
+set -eu
+
+OWNER_REPO="nicolasguelfi/gensem"
+API_LATEST="https://api.github.com/repos/${OWNER_REPO}/releases/latest"
+REGISTRY_FILE="${HOME}/.gse-one"
+
+info() { printf '[gse-one] %s\n' "$*"; }
+warn() { printf '[gse-one] warn: %s\n' "$*" >&2; }
+fail() { printf '[gse-one] error: %s\n' "$*" >&2; exit 1; }
+
+# OS-specific python3 install hint.
+python_install_hint() {
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        Darwin) printf 'brew install python3'; return ;;
+        Linux)  : ;;
+        *)      printf 'install python3 for your OS'; return ;;
+    esac
+    if [ -r /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release 2>/dev/null || true
+        case "${ID:-}${ID_LIKE:-}" in
+            *debian*|*ubuntu*)                         printf 'apt install python3' ;;
+            *rhel*|*fedora*|*centos*|*rocky*|*alma*)   printf 'dnf install python3' ;;
+            *arch*)                                    printf 'pacman -S python' ;;
+            *)                                         printf 'install python3 via your package manager' ;;
+        esac
+    else
+        printf 'install python3 via your package manager'
+    fi
+}
+
+preflight() {
+    command -v curl >/dev/null 2>&1 || fail "curl is required but not found in PATH."
+    command -v tar  >/dev/null 2>&1 || fail "tar is required but not found in PATH."
+    if ! command -v python3 >/dev/null 2>&1; then
+        fail "python3 (>= 3.8) is required but not found. Try: $(python_install_hint)"
+    fi
+    if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,8) else 1)' 2>/dev/null; then
+        pyver=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:3])))' 2>/dev/null || echo unknown)
+        fail "python3 >= 3.8 required; found ${pyver}. Try: $(python_install_hint)"
+    fi
+}
+
+# Detect mode; CWD with .claude/.cursor/.opencode → no-plugin.
+detect_mode() {
+    if [ -n "${GSE_MODE:-}" ]; then printf '%s' "$GSE_MODE"; return; fi
+    if [ -d ".claude" ] || [ -d ".cursor" ] || [ -d ".opencode" ]; then
+        printf 'no-plugin'
+    else
+        printf 'plugin'
+    fi
+}
+
+# Translate detected platforms into install.py --platform value.
+# Passes overrides through as-is; collapses 2+ PATH-detected binaries to 'all'.
+detect_platform_flag() {
+    if [ -n "${GSE_PLATFORM:-}" ]; then printf '%s' "$GSE_PLATFORM"; return; fi
+    found=""
+    command -v claude   >/dev/null 2>&1 && found="$found claude"
+    command -v cursor   >/dev/null 2>&1 && found="$found cursor"
+    command -v opencode >/dev/null 2>&1 && found="$found opencode"
+    count=$(printf '%s' "$found" | wc -w | tr -d ' ')
+    if   [ "$count" -ge 2 ]; then printf 'all'
+    elif [ "$count" -eq 1 ]; then printf '%s' "$(printf '%s' "$found" | tr -d ' ')"
+    fi
+}
+
+resolve_version() {
+    req="${GSE_VERSION:-latest}"
+    if [ -n "$req" ] && [ "$req" != "latest" ]; then printf '%s' "$req"; return; fi
+    info "Resolving latest release via GitHub API..."
+    tag=$(curl -fsSL "$API_LATEST" 2>/dev/null \
+        | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("tag_name",""))
+except Exception: pass' 2>/dev/null || true)
+    [ -n "$tag" ] || fail "Could not resolve latest release from ${API_LATEST}"
+    printf '%s' "$tag"
+}
+
+# Print installed tag (vX.Y.Z) if registry + VERSION file present; empty otherwise.
+installed_version() {
+    [ -f "$REGISTRY_FILE" ] || return 0
+    target=$(cat "$REGISTRY_FILE" 2>/dev/null || true)
+    [ -n "$target" ] && [ -f "$target/VERSION" ] || return 0
+    v=$(tr -d '[:space:]' < "$target/VERSION" 2>/dev/null || true)
+    [ -n "$v" ] && printf 'v%s' "$v"
+}
+
+# Download release tarball and extract into $dest; echo dir containing install.py.
+download_and_extract() {
+    tag=$1; dest=$2
+    url="https://github.com/${OWNER_REPO}/releases/download/${tag}/gse-one.tar.gz"
+    info "Downloading ${url}"
+    curl -fsSL "$url" | tar -xz -C "$dest" \
+        || fail "Failed to download or extract tarball from ${url}"
+    if [ -f "$dest/install.py" ]; then
+        printf '%s' "$dest"; return
+    fi
+    nested=$(find "$dest" -maxdepth 2 -name install.py -print 2>/dev/null | head -n 1)
+    [ -n "$nested" ] && [ -f "$nested" ] || fail "Tarball extracted but install.py not found under ${dest}"
+    dirname "$nested"
+}
+
+# Create temp dir + register cleanup trap; echo the dir.
+make_tmp() {
+    tmp=$(mktemp -d 2>/dev/null || mktemp -d -t gse-one)
+    [ -n "$tmp" ] && [ -d "$tmp" ] || fail "Failed to create temp directory."
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp'" EXIT INT TERM
+    printf '%s' "$tmp"
+}
+
+# Run install.py from the extracted directory (it asserts CWD contains install.py
+# + gse-one/plugin + VERSION) with the given flags.
+run_install_py() {
+    install_root=$1; shift
+    (cd "$install_root" && python3 install.py "$@")
+}
+
+# Shared prelude for install/uninstall: preflight, detect, resolve, download.
+# Sets globals: mode, plat_flag, scope, project_dir, target_tag, install_root.
+prepare() {
+    preflight
+    mode=$(detect_mode)
+    plat_flag=$(detect_platform_flag)
+    scope="${GSE_SCOPE:-user}"
+    project_dir="${GSE_PROJECT_DIR:-}"
+    if [ "$mode" = "no-plugin" ] && [ -z "$project_dir" ]; then
+        project_dir=$(pwd)
+    fi
+
+    target_tag=$(resolve_version)
+    tmp=$(make_tmp)
+    install_root=$(download_and_extract "$target_tag" "$tmp")
+}
+
+subcmd_install() {
+    prepare
+    [ -n "$plat_flag" ] || fail "No supported platform detected (claude, cursor, opencode). Set GSE_PLATFORM to override."
+
+    current=$(installed_version)
+    info "Target version : ${target_tag}"
+    info "Mode           : ${mode}"
+    info "Platforms      : ${plat_flag}"
+    [ -n "$project_dir" ] && info "Project dir    : ${project_dir}"
+    [ "$mode" = "plugin" ] && info "Scope          : ${scope}"
+
+    if [ -n "$current" ] && [ "$current" = "$target_tag" ]; then
+        info "already at ${current} — nothing to do."
+        exit 0
+    fi
+
+    set -- --platform "$plat_flag" --mode "$mode"
+    if [ "$mode" = "plugin" ]; then
+        set -- "$@" --scope "$scope"
+    else
+        set -- "$@" --project-dir "$project_dir"
+    fi
+
+    info "Executing install.py with flags: $*"
+    run_install_py "$install_root" "$@"
+
+    if [ -n "$current" ] && [ "$current" != "$target_tag" ]; then
+        info "upgraded ${current} → ${target_tag}"
+    else
+        info "installed ${target_tag}"
+    fi
+}
+
+subcmd_uninstall() {
+    # Idempotent per US-5: no registry file means nothing to uninstall.
+    if [ ! -f "$REGISTRY_FILE" ]; then
+        info "Nothing installed — ${REGISTRY_FILE} not found. Exiting 0 (idempotent)."
+        exit 0
+    fi
+
+    prepare
+    # If nothing in PATH but registry exists, fall back to 'all'.
+    [ -n "$plat_flag" ] || plat_flag=all
+
+    info "Uninstalling GSE-One (platforms: ${plat_flag}, mode: ${mode}, version: ${target_tag})"
+
+    set -- --uninstall --platform "$plat_flag" --mode "$mode"
+    if [ "$mode" = "no-plugin" ] && [ -n "$project_dir" ]; then
+        set -- "$@" --project-dir "$project_dir"
+    fi
+
+    run_install_py "$install_root" "$@" || warn "install.py --uninstall reported a non-zero exit."
+    info "uninstall complete."
+}
+
+subcmd_upgrade() {
+    GSE_VERSION=latest
+    export GSE_VERSION
+    subcmd_install
+}
+
+usage() {
+    cat <<'EOF'
+GSE-One installer
+
+Usage:
+  install.sh [install]     install or upgrade GSE-One (default)
+  install.sh uninstall     remove GSE-One
+  install.sh upgrade       force-resolve latest and install
+  install.sh -h|--help     show this help
+EOF
+}
+
+main() {
+    case "${1:-install}" in
+        install)         subcmd_install ;;
+        uninstall)       subcmd_uninstall ;;
+        upgrade)         subcmd_upgrade ;;
+        -h|--help|help)  usage ;;
+        *)               usage; fail "Unknown subcommand: ${1:-}" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `install.sh` at repo root implementing Phase 1 of `docs/specs/curl-plugin-based-install.md`.
- POSIX-sh bootstrap that preflights `curl`/`tar`/`python3>=3.8`, auto-detects mode (from CWD) + platforms (from PATH), resolves `GSE_VERSION` via the GitHub releases API (parsed with `python3`, no `jq`), downloads the release tarball to a `mktemp -d` with EXIT-trap cleanup, and delegates to `python3 install.py` with translated flags.
- Supports `install` (default), `uninstall` (idempotent when no registry), and `upgrade` (forces `GSE_VERSION=latest`) subcommands.
- Honors `GSE_PLATFORM` / `GSE_MODE` / `GSE_SCOPE` / `GSE_VERSION` / `GSE_PROJECT_DIR` env overrides.
- OS-specific missing-python3 hint: `brew install python3` (macOS) / `apt install python3` (Debian/Ubuntu) / `dnf install python3` (RHEL-family) / `pacman -S python` (Arch).
- 236 lines (under the 300-line NFR-2 cap). `shellcheck -s sh` clean.
- Does **not** bump VERSION, touch CHANGELOG, or regenerate `gse-one/plugin/` — those are owned by the coordinating release PR after all Phase 1/2/3 units merge.

## Test plan

- [x] `shellcheck -s sh install.sh` exits 0.
- [x] `sh -n install.sh` succeeds.
- [x] Sandboxed dry-run with `GSE_VERSION=v0.62.1 HOME=$(mktemp -d) sh -x install.sh` confirms preflight + auto-detect paths fire correctly (mode, platforms, scope, project_dir all resolved before network call).
- [x] From clean CWD (no `.claude/.cursor/.opencode/`): mode=plugin, scope=user, no project_dir.
- [x] From repo root (has `.claude/`): mode=no-plugin, project_dir=$PWD.
- [x] Multi-platform collapse: 2+ PATH binaries → `--platform all`.
- [x] `sh install.sh uninstall` with no `~/.gse-one` prints idempotent message and exits 0.
- [ ] Full end-to-end install with a real release asset (blocked on Phase 2 CI workflow + tagged release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)